### PR TITLE
Implement config and instance management

### DIFF
--- a/src/MyApp.Server.Common/Helpers/MongoDBHelper.cs
+++ b/src/MyApp.Server.Common/Helpers/MongoDBHelper.cs
@@ -1,11 +1,10 @@
-using Common.Mongo.Collection;
-
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 using MongoDB.Driver;
 
 using Server.Mongo.Collection;
+using Common.Mongo.Collection;
 
 namespace Server.Helpers
 {
@@ -45,7 +44,21 @@ namespace Server.Helpers
                 var logger = sp.GetRequiredService<ILogger<MatchCollection>>();
                 return new MatchCollection(database, logger);
             });
-            
+
+            services.AddSingleton<IConfigsCollection>(sp =>
+            {
+                var database = sp.GetRequiredService<IMongoDatabase>();
+                var logger = sp.GetRequiredService<ILogger<ConfigsCollection>>();
+                return new ConfigsCollection(database, logger);
+            });
+
+            services.AddSingleton<IMatchInstanceCollection>(sp =>
+            {
+                var database = sp.GetRequiredService<IMongoDatabase>();
+                var logger = sp.GetRequiredService<ILogger<MatchInstanceCollection>>();
+                return new MatchInstanceCollection(database, logger);
+            });
+
             return services;
         }
     }

--- a/src/MyApp.Server.Common/Mongo/Collection/ConfigsCollection.cs
+++ b/src/MyApp.Server.Common/Mongo/Collection/ConfigsCollection.cs
@@ -1,0 +1,75 @@
+using Microsoft.Extensions.Logging;
+using MongoDB.Driver;
+using Server.Common.Exceptions;
+using Server.Mongo.Entity;
+
+namespace Server.Mongo.Collection
+{
+    public class ConfigsCollection : IConfigsCollection
+    {
+        private readonly IMongoCollection<Config> _collection;
+        private readonly ILogger<ConfigsCollection> _logger;
+
+        public ConfigsCollection(IMongoDatabase database, ILogger<ConfigsCollection> logger)
+        {
+            _collection = database.GetCollection<Config>("configs") ?? throw new ArgumentNullException(nameof(database));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            CreateIndexes();
+        }
+
+        private void CreateIndexes()
+        {
+            try
+            {
+                var indexOptions = new CreateIndexOptions { Background = true, Unique = true };
+                var keyIndex = new CreateIndexModel<Config>(Builders<Config>.IndexKeys.Ascending(c => c.Key), indexOptions);
+                _collection.Indexes.CreateOne(keyIndex);
+                _logger.LogInformation("Created indexes for Configs collection");
+            }
+            catch (MongoCommandException ex) when (ex.CodeName == "IndexOptionsConflict")
+            {
+                _logger.LogInformation("Indexes already exist for Configs collection");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to create indexes for Configs collection");
+                throw new DatabaseInitializationException("Failed to create indexes", ex);
+            }
+        }
+
+        public async Task<Config?> GetConfigAsync(string key)
+        {
+            if (string.IsNullOrEmpty(key))
+                throw new ArgumentException("Key cannot be null or empty", nameof(key));
+
+            try
+            {
+                return await _collection.Find(c => c.Key == key).FirstOrDefaultAsync();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to retrieve config {Key}", key);
+                throw new DatabaseOperationException("Failed to retrieve config", ex);
+            }
+        }
+
+        public async Task SetConfigAsync(string key, string value)
+        {
+            if (string.IsNullOrEmpty(key))
+                throw new ArgumentException("Key cannot be null or empty", nameof(key));
+
+            var update = Builders<Config>.Update.Set(c => c.Value, value);
+            var options = new UpdateOptions { IsUpsert = true };
+
+            try
+            {
+                await _collection.UpdateOneAsync(c => c.Key == key, update, options);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to set config {Key}", key);
+                throw new DatabaseOperationException("Failed to set config", ex);
+            }
+        }
+    }
+}

--- a/src/MyApp.Server.Common/Mongo/Collection/IConfigsCollection.cs
+++ b/src/MyApp.Server.Common/Mongo/Collection/IConfigsCollection.cs
@@ -1,0 +1,10 @@
+using Server.Mongo.Entity;
+
+namespace Server.Mongo.Collection
+{
+    public interface IConfigsCollection
+    {
+        Task<Config?> GetConfigAsync(string key);
+        Task SetConfigAsync(string key, string value);
+    }
+}

--- a/src/MyApp.Server.Common/Mongo/Collection/IMatchInstanceCollection.cs
+++ b/src/MyApp.Server.Common/Mongo/Collection/IMatchInstanceCollection.cs
@@ -1,0 +1,10 @@
+using Server.Mongo.Entity;
+
+namespace Server.Mongo.Collection
+{
+    public interface IMatchInstanceCollection
+    {
+        Task<MatchInstance?> TryAllocateInstanceAsync(int capacity, int requiredSlots);
+        Task<MatchInstance> CreateInstanceAsync(MatchInstance instance);
+    }
+}

--- a/src/MyApp.Server.Common/Mongo/Collection/MatchInstanceCollection.cs
+++ b/src/MyApp.Server.Common/Mongo/Collection/MatchInstanceCollection.cs
@@ -1,0 +1,72 @@
+using Microsoft.Extensions.Logging;
+using MongoDB.Driver;
+using Server.Mongo.Entity;
+using Server.Common.Exceptions;
+
+namespace Server.Mongo.Collection
+{
+    public class MatchInstanceCollection : IMatchInstanceCollection
+    {
+        private readonly IMongoCollection<MatchInstance> _collection;
+        private readonly ILogger<MatchInstanceCollection> _logger;
+
+        public MatchInstanceCollection(IMongoDatabase database, ILogger<MatchInstanceCollection> logger)
+        {
+            _collection = database.GetCollection<MatchInstance>("matchInstances") ?? throw new ArgumentNullException(nameof(database));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            CreateIndexes();
+        }
+
+        private void CreateIndexes()
+        {
+            try
+            {
+                var indexOptions = new CreateIndexOptions { Background = true };
+                var createdAtIndex = new CreateIndexModel<MatchInstance>(Builders<MatchInstance>.IndexKeys.Ascending(m => m.CreatedAt), indexOptions);
+                _collection.Indexes.CreateOne(createdAtIndex);
+                _logger.LogInformation("Created indexes for MatchInstance collection");
+            }
+            catch (MongoCommandException ex) when (ex.CodeName == "IndexOptionsConflict")
+            {
+                _logger.LogInformation("Indexes already exist for MatchInstance collection");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to create indexes for MatchInstance collection");
+                throw new DatabaseInitializationException("Failed to create indexes", ex);
+            }
+        }
+
+        public async Task<MatchInstance?> TryAllocateInstanceAsync(int capacity, int requiredSlots)
+        {
+            var filter = Builders<MatchInstance>.Filter.Lte(i => i.PlayerCount, capacity - requiredSlots);
+            var update = Builders<MatchInstance>.Update.Inc(i => i.PlayerCount, requiredSlots);
+            var options = new FindOneAndUpdateOptions<MatchInstance> { ReturnDocument = ReturnDocument.After };
+
+            try
+            {
+                return await _collection.FindOneAndUpdateAsync(filter, update, options);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to allocate instance");
+                throw new DatabaseOperationException("Failed to allocate instance", ex);
+            }
+        }
+
+        public async Task<MatchInstance> CreateInstanceAsync(MatchInstance instance)
+        {
+            try
+            {
+                instance.CreatedAt = DateTime.UtcNow;
+                await _collection.InsertOneAsync(instance);
+                return instance;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to create instance document");
+                throw new DatabaseOperationException("Failed to create instance document", ex);
+            }
+        }
+    }
+}

--- a/src/MyApp.Server.Common/Mongo/Entity/Config.cs
+++ b/src/MyApp.Server.Common/Mongo/Entity/Config.cs
@@ -1,0 +1,15 @@
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace Server.Mongo.Entity
+{
+    public class Config
+    {
+        [BsonId]
+        [BsonRepresentation(BsonType.ObjectId)]
+        public string Id { get; set; }
+
+        public string Key { get; set; }
+        public string Value { get; set; }
+    }
+}

--- a/src/MyApp.Server.Common/Mongo/Entity/MatchInstance.cs
+++ b/src/MyApp.Server.Common/Mongo/Entity/MatchInstance.cs
@@ -1,0 +1,17 @@
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace Server.Mongo.Entity
+{
+    public class MatchInstance
+    {
+        [BsonId]
+        [BsonRepresentation(BsonType.ObjectId)]
+        public string Id { get; set; }
+
+        public string Url { get; set; } = string.Empty;
+        public int Port { get; set; }
+        public int PlayerCount { get; set; }
+        public DateTime CreatedAt { get; set; }
+    }
+}

--- a/src/MyApp.Server.Services/MyApp.Server.Services.csproj
+++ b/src/MyApp.Server.Services/MyApp.Server.Services.csproj
@@ -12,6 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Google.Cloud.Run.V2" Version="1.4.0" />
     <PackageReference Include="MagicOnion" Version="6.1.4" />
     <PackageReference Include="MagicOnion.Server" Version="7.0.4" />
     <PackageReference Include="MessagePack.UnityShims" Version="3.1.3" />

--- a/src/MyApp.Server.Services/Program.cs
+++ b/src/MyApp.Server.Services/Program.cs
@@ -20,10 +20,11 @@ namespace Server
 
             // Configure MagicOnion with proper gRPC settings
             builder.Services.ConfigureMagicOnion();
-            
+
             // Add your services
             builder.Services.AddScoped<PlayersService>();
             builder.Services.AddScoped<MatchMakerService>();
+            builder.Services.AddSingleton<MatchInstanceService>();
             
             var app = builder.Build();
             

--- a/src/MyApp.Server.Services/Services/MatchInstanceService.cs
+++ b/src/MyApp.Server.Services/Services/MatchInstanceService.cs
@@ -1,0 +1,81 @@
+using Google.Cloud.Run.V2;
+using Google.Api.Gax.ResourceNames;
+using Microsoft.Extensions.Logging;
+using Server.Mongo.Collection;
+using Server.Mongo.Entity;
+
+namespace Server.Services
+{
+    public class MatchInstanceService
+    {
+        private readonly IMatchInstanceCollection _instances;
+        private readonly ILogger<MatchInstanceService> _logger;
+        private readonly int _capacityPerInstance;
+
+        public MatchInstanceService(IMatchInstanceCollection instances,
+                                     ILogger<MatchInstanceService> logger,
+                                     int capacityPerInstance = 100)
+        {
+            _instances = instances;
+            _logger = logger;
+            _capacityPerInstance = capacityPerInstance;
+        }
+
+        public async Task<MatchInstance> AllocateInstanceAsync(int requiredSlots)
+        {
+            var instance = await _instances.TryAllocateInstanceAsync(_capacityPerInstance, requiredSlots);
+            if (instance != null)
+            {
+                return instance;
+            }
+
+            instance = await ProvisionNewInstanceAsync();
+            instance.PlayerCount = requiredSlots;
+            await _instances.CreateInstanceAsync(instance);
+            return instance;
+        }
+
+        private async Task<MatchInstance> ProvisionNewInstanceAsync()
+        {
+            var projectId = Environment.GetEnvironmentVariable("GCP_PROJECT_ID") ?? "clashcore";
+            var region = Environment.GetEnvironmentVariable("GCP_REGION") ?? "us-central1";
+            var image = Environment.GetEnvironmentVariable("GAMEHUB_IMAGE") ??
+                         $"{region}-docker.pkg.dev/{projectId}/clashcore-gamehub/clashcore-gamehub:latest";
+
+            var parent = LocationName.FromProjectLocation(projectId, region);
+            var serviceId = $"gamehub-{Guid.NewGuid():N}";
+
+            var client = await ServicesClient.CreateAsync();
+            var request = new CreateServiceRequest
+            {
+                Parent = parent.ToString(),
+                ServiceId = serviceId,
+                Service = new Service
+                {
+                    Template = new RevisionTemplate
+                    {
+                        Containers =
+                        {
+                            new Google.Cloud.Run.V2.Container
+                            {
+                                Image = image,
+                                Ports = { new ContainerPort { ContainerPort_ = 12346 } }
+                            }
+                        }
+                    }
+                }
+            };
+
+            var op = await client.CreateServiceAsync(request);
+            var result = await op.PollUntilCompletedAsync();
+            var url = result.Result.Uri ?? string.Empty;
+
+            return new MatchInstance
+            {
+                Url = url,
+                Port = 12346,
+                PlayerCount = 0
+            };
+        }
+    }
+}

--- a/src/MyApp.Server.Services/Services/MatchMakerService.cs
+++ b/src/MyApp.Server.Services/Services/MatchMakerService.cs
@@ -12,6 +12,8 @@ using Server.Mongo.Entity;
 
 using Shared.Data;
 using Shared.Services;
+using System.Text.Json;
+using System.Collections.Generic;
 
 using MatchType = Shared.Data.MatchType;
 
@@ -21,15 +23,23 @@ namespace Server.Services
     {
         private readonly IMongoClient _mongoClient;
         private readonly IMatchCollection _matches;
+        private readonly IConfigsCollection _configs;
+        private readonly MatchInstanceService _instanceService;
         private readonly ILogger<MatchMakerService> _logger;
+
+        private Dictionary<MatchType, MatchConfig>? _matchConfigs;
 
         public MatchMakerService(IMongoClient mongoClient,
                                  ILogger<MatchMakerService> logger,
-                                 IMatchCollection matches)
+                                 IMatchCollection matches,
+                                 IConfigsCollection configs,
+                                 MatchInstanceService instanceService)
         {
             _mongoClient = mongoClient;
             _logger = logger;
             _matches = matches;
+            _configs = configs;
+            _instanceService = instanceService;
         }
 
         public UnaryResult<string> Test()
@@ -45,7 +55,8 @@ namespace Server.Services
             _logger.LogInformation(
                 $"Player {playerId} is trying to join match of type {matchType} with matchId {matchId ?? "none"}");
             
-            var maxPlayers = GetMaxPlayers(matchType);
+            var matchConfig = await GetMatchConfigAsync(matchType);
+            var maxPlayers = matchConfig.MaxPlayers;
 
             using var session = await _mongoClient.StartSessionAsync();
             session.StartTransaction();
@@ -105,19 +116,37 @@ namespace Server.Services
             }
         }
         
-        private int GetMaxPlayers(MatchType type)
+        private async Task<MatchConfig> GetMatchConfigAsync(MatchType type)
         {
-            return type switch
+            if (_matchConfigs == null)
             {
-                MatchType.Default => 10, _ => 10
-            };
+                var config = await _configs.GetConfigAsync(MatchConfig.MatchesConfigKey);
+                if (config == null)
+                {
+                    throw new RpcException(new Status(StatusCode.Internal, "Match configuration missing"));
+                }
+
+                var dict = JsonSerializer.Deserialize<Dictionary<string, MatchConfig>>(config.Value)
+                           ?? new Dictionary<string, MatchConfig>();
+                _matchConfigs = dict.ToDictionary(k => Enum.Parse<MatchType>(k.Key, true), v => v.Value);
+            }
+
+            if (_matchConfigs.TryGetValue(type, out var matchConfig))
+            {
+                return matchConfig;
+            }
+
+            throw new RpcException(new Status(StatusCode.Internal, $"Configuration for match type {type} not found"));
         }
 
         private async Task<Match> CreateMatchAsync(MatchType type,
                                                    string playerId,
                                                    IClientSessionHandle session)
         {
-            var (url, port) = AllocateServerEndpoint(type);
+            var matchConfig = await GetMatchConfigAsync(type);
+            var instance = await _instanceService.AllocateInstanceAsync(matchConfig.MaxPlayers);
+            var url = instance.Url;
+            var port = instance.Port;
 
             var match = await _matches.CreateMatchAsync(new()
             {
@@ -127,11 +156,5 @@ namespace Server.Services
             return match;
         }
 
-        private static (string url, int port) AllocateServerEndpoint(MatchType type)
-        {
-            // quick placeholder – eg. choose random port on localhost
-            // integrate with real pool later.
-            return ("localhost", 12346);
-        }
     }
 }

--- a/src/MyApp.Shared/Data/MatchConfig.cs
+++ b/src/MyApp.Shared/Data/MatchConfig.cs
@@ -1,0 +1,10 @@
+namespace Shared.Data
+{
+    public class MatchConfig
+    {
+        public const string MatchesConfigKey = "MatchesConfig";
+
+        public int MaxPlayers { get; set; }
+        public int NumberOfTeams { get; set; }
+    }
+}

--- a/src/MyApp.Shared/Data/MatchType.cs
+++ b/src/MyApp.Shared/Data/MatchType.cs
@@ -2,7 +2,7 @@
 {
     public enum MatchType
     {
-        None = 0,
-        Default = 1
+        None,
+        Casual
     }
 }

--- a/src/MyApp.Unity/Assets/App/SubDomains/Game/Scripts/GameStarter.cs
+++ b/src/MyApp.Unity/Assets/App/SubDomains/Game/Scripts/GameStarter.cs
@@ -60,7 +60,7 @@ namespace App.SubDomains.Game.Scripts
             _debugService.Log($"GameStarter: MatchMakerService test result: {test}");
 
             var matchData =
-                await _matchMakerService.JoinMatchAsync(playerId, MatchType.Default, string.Empty);
+                await _matchMakerService.JoinMatchAsync(playerId, MatchType.Casual, string.Empty);
             
             _debugService.Log($"GameStarter: Player {playerId} joined match {matchData.MatchId} at {matchData.Url}:{matchData.Port}.");
             _networkService.CreateMatchChannel(matchData.Url, matchData.Port);


### PR DESCRIPTION
## Summary
- add MongoDB collection for configs
- support match configuration retrieval in MatchMakerService
- add Cloud Run based instance allocation
- persist match instances via new collection
- register new services with DI
- update match type enum and game starter example

## Testing
- `dotnet build src/MyApp.Server.Services/MyApp.Server.Services.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_688a65b1c73c832a948533e23f2b8cdf